### PR TITLE
docker-puppeteer to 1.1.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: docker-puppeteer
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.1.6
+  version: 1.1.7
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote docker-puppeteer to version 1.1.7